### PR TITLE
Get engagement for a video

### DIFF
--- a/server/lib/mave_metrics/stats.ex
+++ b/server/lib/mave_metrics/stats.ex
@@ -112,6 +112,7 @@ defmodule MaveMetrics.Stats do
 
   def refresh_daily_aggregation() do
     Repo.query!("REFRESH MATERIALIZED VIEW daily_session_aggregation;")
+    Repo.query!("REFRESH MATERIALIZED VIEW video_views_per_second_aggregate;")
   end
 
   defp float_video_time(attrs) do

--- a/server/lib/mave_metrics_web/controllers/api/engagement_controller.ex
+++ b/server/lib/mave_metrics_web/controllers/api/engagement_controller.ex
@@ -1,0 +1,26 @@
+defmodule MaveMetricsWeb.API.EngagementController do
+  use MaveMetricsWeb, :controller
+
+  alias MaveMetrics.API
+
+  def get_engagement(conn, _params) do
+    {:ok, body, _conn} = Plug.Conn.read_body(conn)
+    params = Jason.decode!(body)
+    conn |> engagement(params)
+  end
+
+  def engagement(conn, %{"query" => query} = params) do
+    result = API.get_engagement(query, params["interval"], params["timeframe"])
+
+    conn
+    |> json(%{engagement: result})
+    |> halt
+  end
+
+  def engagement(conn, _params) do
+    conn
+    |> put_status(400)
+    |> json(%{error: "Requires a valid JSON query struct."})
+    |> halt
+  end
+end

--- a/server/lib/mave_metrics_web/controllers/api/sources_controller.ex
+++ b/server/lib/mave_metrics_web/controllers/api/sources_controller.ex
@@ -9,24 +9,14 @@ defmodule MaveMetricsWeb.API.SourcesController do
     conn |> sources(params)
   end
 
-  def sources(conn, %{"identifier" => identifier, "query" => query} = params) do
-    result = API.get_sources({identifier, query}, params["interval"], params["timeframe"], params["minimum_watch_seconds"])
-
-    conn
-    |> json(%{sources: result})
-    |> halt
-  end
-
-  def sources(conn, %{"identifier" => identifier} = params) do
-    result = API.get_sources(identifier, params["interval"], params["timeframe"], params["minimum_watch_seconds"])
-
-    conn
-    |> json(%{sources: result})
-    |> halt
-  end
-
   def sources(conn, %{"query" => filters} = params) do
-    result = API.get_sources(filters, params["interval"], params["timeframe"], params["minimum_watch_seconds"])
+    result =
+      API.get_sources(
+        filters,
+        params["interval"],
+        params["timeframe"],
+        params["minimum_watch_seconds"]
+      )
 
     conn
     |> json(%{sources: result})

--- a/server/lib/mave_metrics_web/controllers/api/views_controller.ex
+++ b/server/lib/mave_metrics_web/controllers/api/views_controller.ex
@@ -9,24 +9,14 @@ defmodule MaveMetricsWeb.API.ViewsController do
     conn |> views(params)
   end
 
-  def views(conn, %{"identifier" => identifier, "query" => query} = params) do
-    result = API.get_plays({identifier, query}, params["interval"], params["timeframe"], params["minimum_watch_seconds"])
-
-    conn
-    |> json(%{views: result})
-    |> halt
-  end
-
-  def views(conn, %{"identifier" => identifier} = params) do
-    result = API.get_plays(identifier, params["interval"], params["timeframe"], params["minimum_watch_seconds"])
-
-    conn
-    |> json(%{views: result})
-    |> halt
-  end
-
   def views(conn, %{"query" => filters} = params) do
-    result = API.get_plays(filters, params["interval"], params["timeframe"], params["minimum_watch_seconds"])
+    result =
+      API.get_plays(
+        filters,
+        params["interval"],
+        params["timeframe"],
+        params["minimum_watch_seconds"]
+      )
 
     conn
     |> json(%{views: result})

--- a/server/lib/mave_metrics_web/router.ex
+++ b/server/lib/mave_metrics_web/router.ex
@@ -24,6 +24,8 @@ defmodule MaveMetricsWeb.Router do
     get("/views", API.ViewsController, :get_views)
     post("/sources", API.SourcesController, :sources)
     get("/sources", API.SourcesController, :get_sources)
+    post("/engagement", API.EngagementController, :engagement)
+    get("/engagement", API.EngagementController, :get_engagement)
 
     post("/keys", API.KeysController, :create_key)
     get("/keys", API.KeysController, :get_keys)

--- a/server/priv/repo/migrations/20240226221750_add_engagement.exs
+++ b/server/priv/repo/migrations/20240226221750_add_engagement.exs
@@ -1,0 +1,32 @@
+defmodule MaveMetrics.Repo.Migrations.AddEngagement do
+  use Ecto.Migration
+
+  def change do
+    execute("""
+    CREATE MATERIALIZED VIEW IF NOT EXISTS video_views_per_second_per_day_aggregate AS
+      SELECT
+        e.video_id,
+        DATE(e.timestamp) AS event_date,
+        gs.second AS video_second,
+        COUNT(*) AS views
+      FROM
+        events e
+      JOIN
+        events e_next ON e.session_id = e_next.session_id
+                      AND e_next.type = 'pause'
+                      AND e_next.timestamp > e.timestamp
+                      AND e.type = 'play',
+      LATERAL
+        generate_series(
+          floor(e.video_time)::int,
+          ceil(e_next.video_time)::int - 1
+        ) AS gs(second)
+      GROUP BY
+        e.video_id, DATE(e.timestamp), gs.second;
+    """)
+
+    execute("""
+    CREATE INDEX ON video_views_per_second_per_day_aggregate (video_id, event_date, video_second);
+    """)
+  end
+end


### PR DESCRIPTION
In our our previous metrics we did had `/v1/engagement`, but that didn't work efficient. So this is a redo of the original engagement controller, using the similar query you can use for views en sources.


## Request

```json
{
    "query": {
        "video": {
            "video_id": "GMYmeLeJPmSfvxX8VYek2S"
        }
    },
    "interval": "1 month"
}
``` 

## Response

```json
{
    "engagement": [
        {
            "interval": "2024-02-01",
            "per_second": [
                {
                    "second": 0,
                    "views": 24
                },
                {
                    "second": 1,
                    "views": 17
                },
                {
                    "second": 2,
                    "views": 13
                },
                {
                    "second": 3,
                    "views": 12
                },
                {
                    "second": 4,
                    "views": 11
                },
                {
                    "second": 5,
                    "views": 5
                },
                {
                    "second": 6,
                    "views": 2
                },
                {
                    "second": 7,
                    "views": 2
                },
                {
                    "second": 8,
                    "views": 2
                },
                {
                    "second": 9,
                    "views": 2
                },
                {
                    "second": 10,
                    "views": 2
                },
                {
                    "second": 11,
                    "views": 2
                }
            ]
        }
    ]
}
```