### PR TITLE
Fix events for when users scrubs through time

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maveio/metrics",
-  "version": "0.0.12",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maveio/metrics",
-      "version": "0.0.12",
+      "version": "0.1.3",
       "license": "APGL-3.0",
       "dependencies": {
         "phoenix": "^1.7.10"


### PR DESCRIPTION
It seems `seeked` was unreliable and I was using weird methods to catch the time. So I simplified it and just check in a `timeupdate` whether there is a huge gab and assume its a scrub when playing. Which results in a pause + play event.